### PR TITLE
Ported to Python 3 and WeeWX V4

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+0.8 08may2020
+* Ported to Python 3 and WeeWX V4. -tk
+
 0.7 25apr2016
 * remove dependency on wx_binding
 

--- a/install.py
+++ b/install.py
@@ -1,16 +1,17 @@
-# $Id: install.py 1483 2016-04-25 06:53:19Z mwall $
 # installer for ThinkSpeak
-# Copyright 2014 Matthew Wall
+# Copyright 2014-2020 Matthew Wall
 
-from setup import ExtensionInstaller
+from weecfg.extension import ExtensionInstaller
+
 
 def loader():
     return ThingSpeakInstaller()
 
+
 class ThingSpeakInstaller(ExtensionInstaller):
     def __init__(self):
         super(ThingSpeakInstaller, self).__init__(
-            version="0.7",
+            version="0.8",
             name='thingspeak',
             description='Upload weather data to ThingSpeak.',
             author="Matthew Wall",
@@ -19,6 +20,6 @@ class ThingSpeakInstaller(ExtensionInstaller):
             config={
                 'StdRESTful': {
                     'ThingSpeak': {
-                        'token': 'INSERT_TOKEN_HERE'}}},
+                        'api_key': 'INSERT_TOKEN_HERE'}}},
             files=[('bin/user', ['bin/user/thingspeak.py'])]
-            )
+        )


### PR DESCRIPTION
Double check the install program. It had

```python
            config={
                'StdRESTful': {
                    'ThingSpeak': {
                        'token': 'INSERT_TOKEN_HERE'}}},
```

which I changed to

```python
            config={
                'StdRESTful': {
                    'ThingSpeak': {
                        'api_key': 'INSERT_TOKEN_HERE'}}},
```

I.e., `api_key` instead of `token`